### PR TITLE
Export bot reply and add tests

### DIFF
--- a/components/ChatDock.tsx
+++ b/components/ChatDock.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 
-function getBotReply(userMsg: string) {
+export function getBotReply(userMsg: string) {
   // Simple demo: echo or respond to keywords
   if (/dairy[- ]?free/i.test(userMsg)) return "Okay! I'll mark some meals as dairy-free.";
   if (/hello|hi|hey/i.test(userMsg)) return "Hello! How can I help you with your meal plan?";

--- a/components/__tests__/ChatDock.test.ts
+++ b/components/__tests__/ChatDock.test.ts
@@ -1,0 +1,16 @@
+import { getBotReply } from "../ChatDock";
+
+describe("getBotReply", () => {
+  test("dairy free", () => {
+    expect(getBotReply("dairy free")).toBe("Okay! I'll mark some meals as dairy-free.");
+  });
+
+  test("hello", () => {
+    expect(getBotReply("hello")).toBe("Hello! How can I help you with your meal plan?");
+  });
+
+  test("unknown input", () => {
+    expect(getBotReply("what's up?")).toBe("I'm still learning! Try asking about allergies, meals, or groceries.");
+  });
+});
+


### PR DESCRIPTION
## Summary
- export `getBotReply` from ChatDock for direct testing
- add Jest tests covering dairy free, hello, and unknown input responses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c79137a0833283cac0614fe4ef03