### PR TITLE
docs: clarify getBotReply comment

### DIFF
--- a/components/ChatDock.tsx
+++ b/components/ChatDock.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 
 function getBotReply(userMsg: string) {
-  // Simple demo: echo or respond to keywords
+  // Simple demo: replies only when certain keywords are detected
   if (/dairy[- ]?free/i.test(userMsg)) return "Okay! I'll mark some meals as dairy-free.";
   if (/hello|hi|hey/i.test(userMsg)) return "Hello! How can I help you with your meal plan?";
   if (/chicken/i.test(userMsg)) return "Chicken is a great source of protein!";


### PR DESCRIPTION
## Summary
- Clarify that the bot replies only when certain keywords are detected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c78c22288332a85914dc45c2286d